### PR TITLE
Support for different types of effect parameters

### DIFF
--- a/src/components/SamplePad.js
+++ b/src/components/SamplePad.js
@@ -16,7 +16,7 @@ export function SamplePad(props) {
       props.sample.setEndPlaybackCallback(() => setPlaying(false));
     }
     setPlaying(!isPlaying);
-  }
+  };
 
   return (
     <div>

--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -18,7 +18,7 @@ export function SamplePlayer(props) {
   };
   const stopSample = (sampleIndex) => {
     samples[sampleIndex].stop(props.playback.GetNextBar());
-  }
+  };
 
   const openFXPanel = (index) => {
     index != selectedSample
@@ -51,9 +51,15 @@ export function SamplePlayer(props) {
             position: "absolute",
             top: "0px",
             left: "0px",
-            width: "100%"
+            width: "100%",
           }}>
-          <FXPanel sample={sample} mouseController={props.mouseController} />
+          <FXPanel
+            effects={sample.fx.effects}
+            panelColor={sample.color}
+            setFxParam={(fxName, param, value) =>
+              sample.fx.setFxParam(fxName, param, value)
+            }
+          />
         </div>
       </div>
     );
@@ -61,9 +67,9 @@ export function SamplePlayer(props) {
 
   return (
     <Grid container spacing={2}>
-        <Grid item xs={6}>
-          {fxPanels}
-        </Grid>
+      <Grid item xs={6}>
+        {fxPanels}
+      </Grid>
       <Grid container item xs={6} spacing={2}>
         <Grid container>{samplePads}</Grid>
       </Grid>


### PR DESCRIPTION
This PR introduces the following:

- Rework of how effect parameters are set and handled.
- New `FxParamSlider` component.
- Introduced a `FxParam` class for managing effect parameters. Some effects are readonly meaning that we can't modify them on the go but rather have to reinstate the whole effect node.
- Tidied up the grid to make it more compatible with small/medium screens.