### PR TITLE
Move to 16th note scheduling

### DIFF
--- a/src/components/SamplePlayer.js
+++ b/src/components/SamplePlayer.js
@@ -8,16 +8,10 @@ export function SamplePlayer(props) {
   const samples = props.sampler.getSamples();
 
   const playSample = (sampleIndex) => {
-    if (!props.playback.started) {
-      props.playback.start(0.1);
-      samples[sampleIndex].play("0:0:0");
-    } else {
-      console.log(props.playback.GetNextBar());
-      samples[sampleIndex].play(props.playback.GetNextBar());
-    }
+    props.sampler.playSample(sampleIndex);
   };
   const stopSample = (sampleIndex) => {
-    samples[sampleIndex].stop(props.playback.GetNextBar());
+    props.sampler.stopSample(sampleIndex);
   };
 
   const openFXPanel = (index) => {

--- a/src/controllers/PlaybackController.js
+++ b/src/controllers/PlaybackController.js
@@ -24,9 +24,13 @@ export class PlaybackController {
     this.beatCallback = fn;
   }
   tick(time) {
-    const nextSixteenth = Tone.Time(Tone.Time(time) + Tone.Time("16n"))
-    const timestamp = nextSixteenth.toBarsBeatsSixteenths().split(".")[0];
+    const timestamp = Tone.Time(time).toBarsBeatsSixteenths().split(".")[0];
     const [bar, beat, sixteenth] = timestamp.split(":");
+
+    // Trigger next set of samples
+    if (beat === "3" && sixteenth === "3") {
+      this.sampleController.tick(time);
+    }
 
     // Update visuals every quarter note, prescheduling 1/16th ahead
     Tone.Draw.schedule(function () {
@@ -42,10 +46,6 @@ export class PlaybackController {
         // Any other callbacks
         this.beatCallback?.(beat);
       }
-
     }, "+16n");
-  }
-  GetNextBar() {
-    return Tone.Transport.nextSubdivision("1n");
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, {useRef, useEffect} from "react";
+import React, {useRef, useEffect, useState} from "react";
 import ReactDOM from "react-dom";
 import {SamplePlayer} from "./components/SamplePlayer.js";
 import Grid from "@material-ui/core/Grid";
@@ -15,28 +15,51 @@ if (process.env.NODE_ENV !== "production") {
   console.log("Looks like we are in development mode!");
 }
 
+function StartModal(props) {
+  return (
+    <div className="startModal">
+      <p>
+        <a href="#" className="start" onClick={() => props.start()}>
+          Start
+        </a>
+      </p>
+    </div>
+  );
+}
+
 function App(props) {
   const mouseController = useRef(props.mouseController);
   const sampler = useRef(new SampleController());
   const playback = useRef(new PlaybackController(sampler.current));
+  const [initialised, setInitialised] = useState(false);
 
-  useEffect(() => {
-  });
+  const start = function () {
+    playback.current.start(0.1);
+    // Start off with first sample playing
+    sampler.current.playSample(0);
+    setInitialised(true);
+  };
 
   return (
     <ThemeProvider theme={synthTheme}>
-      <Grid container justifyContent="center" alignItems="center" spacing={2}>
-      <Grid item xs={12}>
-        <p style={{textAlign: 'center'}} id="timestamp">0:0:0</p>
-      </Grid>
-        <Grid item xs={12}>
-          <SamplePlayer
-            sampler={sampler.current}
-            mouseController={mouseController}
-            playback={playback.current}
-          />
+      {initialised ? (
+        <Grid container justifyContent="center" alignItems="center" spacing={2}>
+          <Grid item xs={12}>
+            <p style={{textAlign: "center"}} id="timestamp">
+              0:0:0
+            </p>
+          </Grid>
+          <Grid item xs={12}>
+            <SamplePlayer
+              sampler={sampler.current}
+              mouseController={mouseController}
+              playback={playback.current}
+            />
+          </Grid>
         </Grid>
-      </Grid>
+      ) : (
+        <StartModal start={() => start()} />
+      )}
     </ThemeProvider>
   );
 }

--- a/src/style.css
+++ b/src/style.css
@@ -47,3 +47,39 @@
 .fxLabel {
     font-size: 20px;
 }
+.startModal {
+    background-color: #FFF;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    font-size: 128px;
+    text-align: center;
+}
+.startModal p {
+    line-height: 1.5;
+    display: inline-block;
+    vertical-align: middle;
+}
+.startModalContent {
+    margin: auto;
+    width: 100%;
+}
+
+.startModal a {
+    text-decoration: none;
+}
+.startModal a:link {
+    color: red;
+}
+.startModal a:visited {
+    color: green;
+}
+.startModal a:hover {
+    color: hotpink;
+}
+.startModal a:active {
+    color: blue;
+}


### PR DESCRIPTION
The previous way of scheduling involved scheduling for a specific time
ahead, e.g. start of measure 6. While brilliant on paper, in practice
it didn't work as the target time would end up being highly inaccurate.
The inaccuracies would become more and more clear if a loop was present
for a long time as the deviations from rhythm would keep on increasing.

The fix for that was moving to a system that triggers samples right
before they are meant to be played.

This also introduces a modular "Start" dialog for starting playback.