### PR TITLE
Fix UI scale bug in XYPadStyled

### DIFF
--- a/dist/style.css
+++ b/dist/style.css
@@ -1091,8 +1091,8 @@ p {
 
 .xyPad {
   position: absolute;
-  width: 190px;
-  height: 190px;
+  width: 182px;
+  height: 182px;
   top:436px;
   left:18px;
 }

--- a/src/components/ComponentA.js
+++ b/src/components/ComponentA.js
@@ -1,11 +1,10 @@
-import React, {useState, useEffect} from "react";
+import React from "react";
 
 import {DiscreteSlider} from "./DiscreteSlider.js";
 import {DownSlider} from "./DownSlider.js";
 import {InstrumentGroup} from "./InstrumentGroup.js";
 import {MultistateSwitch} from "./MultistateSwitch.js";
 import {XYPadStyled} from "./XYPadStyled.js";
-import {scale} from "../utils/Math.js";
 
 export function ComponentA(props) {
   const sliderControl = props.group.getFxControls()["slider"];
@@ -19,13 +18,10 @@ export function ComponentA(props) {
     const desc = props.description.getXYPadDescription();
     fxXYComponent = (
       <XYPadStyled
-        minValue={0}
-        maxValue={123}
-        trackerSize={57}
         boxClassName={desc.getBoxClassName()}
         trackerClassName={desc.getTrackerClassName()}
-        callbackX={(val) => xyControl.setX(scale(val, 0, 123, 0, 1))} // Need to scale to [0, 1]
-        callbackY={(val) => xyControl.setY(scale(val, 0, 123, 0, 1))} // Need to scale to [0, 1]
+        callbackX={(val) => xyControl.setX(val)}
+        callbackY={(val) => xyControl.setY(val)}
         mouseController={props.mouseController}
       />
     );

--- a/src/components/XYPadStyled.js
+++ b/src/components/XYPadStyled.js
@@ -1,90 +1,137 @@
 import React, {useState, useEffect} from "react";
 
 import {uuidv4} from "../utils/GUID.js";
-import {clamp} from "../utils/Math.js";
+import {clamp, scale} from "../utils/Math.js";
 import {useLocalContext} from "../utils/ReactHelpers.js";
 
-export function XYPadStyled(props) {
-  const minValue = props.minValue;
-  const maxValue = props.maxValue; // equivalent to squre size
-  const size = props.trackerSize;
-  const trackerMiddle = size / 2;
+// Dirty hack to pick up current UI scale. Sorry.
+function getUIScale() {
+  const transform = window.getComputedStyle(
+    document.getElementById("mainContainer")
+  ).transform;
+  // "matrix(0.7, 0, 0, 0.7, 0, -114.464)"
+  if (transform && transform !== "none") {
+    const scale = parseFloat(transform.split("(")[1].split(",")[0]);
+    return 1 / scale;
+  }
+  return 1;
+}
 
-  const [x, setX] = useState(maxValue / 2);
-  const [y, setY] = useState(maxValue / 2);
+export function XYPadStyled(props) {
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(0);
 
   const [componentId, setComponentId] = useState(uuidv4());
   const ctx = useLocalContext({x, y, componentId});
+
+  const getRelativePosition = (x, y, rect, trackerSize, scale) => {
+    const trackerMiddle = trackerSize / 2;
+    const relativeX = x - rect.x - trackerMiddle;
+    const relativeY = y - rect.y - trackerMiddle;
+
+    // Constrain
+    const constrainedX = clamp(relativeX, 0, rect.width - trackerSize);
+    const constrainedY = clamp(relativeY, 0, rect.height - trackerSize);
+
+    return [constrainedX * scale, constrainedY * scale];
+  };
+
+  const normalisePosition = (x, y, rect) => {
+    // Scale to [0, 1]
+    const scaledX = scale(x, 0, rect.width, 0, 1);
+    const scaledY = scale(y, 0, rect.height, 0, 1);
+    return [scaledX, scaledY];
+  };
 
   const mouseMove = React.useCallback(
     (e) => {
       if (e.dragOrigin != null) {
         const thisElement =
-          e.dragOrigin.id === componentId ||
-          e.dragOrigin.parentElement?.id === componentId;
+          e.dragOrigin.id === componentId || e.dragOrigin.id === "xyPadTracker";
         if (e.isDragging && thisElement) {
           const rect = document
             .getElementById(componentId)
             .getBoundingClientRect();
 
-          // Movement deltas
-          const deltaX = e.clientX - rect.left - trackerMiddle;
-          const deltaY = e.clientY - rect.top - trackerMiddle;
+          const trackerSize = document
+            .getElementById("xyPadTracker")
+            .getBoundingClientRect().width;
 
-          // Apply and constrain
-          const constrainedX = clamp(deltaX, minValue, maxValue);
-          const constrainedY = clamp(deltaY, minValue, maxValue);
+          // Calculate pos relative to dom element
+          const [relativeX, relativeY] = getRelativePosition(
+            e.clientX,
+            e.clientY,
+            rect,
+            trackerSize,
+            getUIScale()
+          );
+
+          // Transform to [0, 1] space
+          const [normalX, normalY] = normalisePosition(
+            relativeX,
+            relativeY,
+            rect
+          );
 
           // Only update state if value has changed
-          if (Math.abs(constrainedX - ctx.x) > 0.0000001) {
-            if (props.callbackX) props.callbackX(constrainedX);
-            setX(constrainedX);
+          if (Math.abs(relativeX - ctx.x) > 0.0000001) {
+            if (props.callbackX) props.callbackX(normalX);
+            setX(relativeX);
           }
-          if (Math.abs(constrainedY - ctx.y) > 0.0000001) {
-            if (props.callbackY) props.callbackY(constrainedY);
-            setY(constrainedY);
+          if (Math.abs(relativeY - ctx.y) > 0.0000001) {
+            if (props.callbackY) props.callbackY(normalY);
+            setY(relativeY);
           }
         }
       }
     },
-    [minValue, maxValue, props.callbackX, props.callbackY]
+    [props.callbackX, props.callbackY]
   );
 
   const mouseDown = React.useCallback((e) => {
     // Check if we clicked on one of the elements in the SVG
     const thisElement =
-      e.target.id === componentId ||
-      (e.target.parentElement && e.target.parentElement.id === componentId);
+      e.target.id === componentId || e.target.id === "xyPadTracker";
     if (thisElement) {
       const componentDom = document.getElementById(componentId);
       componentDom.style.cursor = "none";
       const rect = componentDom.getBoundingClientRect();
-      // Apply and constrain
-      const constrainedX = clamp(
-        e.clientX - rect.left - trackerMiddle,
-        minValue,
-        maxValue
+      const trackerSize = document
+        .getElementById("xyPadTracker")
+        .getBoundingClientRect().width;
+
+      // Calculate pos relative to dom element
+      const [relativeX, relativeY] = getRelativePosition(
+        e.clientX,
+        e.clientY,
+        rect,
+        trackerSize,
+        getUIScale()
       );
-      const constrainedY = clamp(
-        e.clientY - rect.top - trackerMiddle,
-        minValue,
-        maxValue
-      );
-      setX(constrainedX);
-      setY(constrainedY);
-      if (ctx.callbackX) ctx.callbackX(constrainedX);
-      if (ctx.callbackY) ctx.callbackY(constrainedY);
+
+      // Transform to [0, 1] space
+      const [normalX, normalY] = normalisePosition(relativeX, relativeY, rect);
+
+      setX(relativeX);
+      setY(relativeY);
+      if (ctx.callbackX) ctx.callbackX(normalX);
+      if (ctx.callbackY) ctx.callbackY(normalY);
     }
   });
 
-  const mouseUp = (e) => {
+  const mouseUp = (_) => {
     const componentDom = document.getElementById(componentId);
     if (componentDom !== null) componentDom.style.cursor = "default";
   };
 
   useEffect(() => {
-    setX(maxValue / 2);
-    setY(maxValue / 2);
+    const rect = document.getElementById(componentId).getBoundingClientRect();
+    const trackerSize = document
+      .getElementById("xyPadTracker")
+      .getBoundingClientRect().width;
+    const trackerMiddle = trackerSize / 2;
+    setX((rect.width / 2 - trackerMiddle) * getUIScale());
+    setY((rect.height / 2 - trackerMiddle) * getUIScale());
 
     props.mouseController.registerListener(componentId, "mouseDown", mouseDown);
     props.mouseController.registerListener(componentId, "mouseMove", mouseMove);
@@ -99,7 +146,10 @@ export function XYPadStyled(props) {
 
   return (
     <div className={props.boxClassName} id={componentId}>
-      <div className={props.trackerClassName} style={{top: y, left: x}}></div>
+      <div
+        id={"xyPadTracker"}
+        className={props.trackerClassName}
+        style={{top: y, left: x}}></div>
     </div>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function App(props) {
     {initialised ? <div className="darkBackgroundLayer"/> : null}
     {popup}
 
-    <div className={"mainContainer" + (initialised ? "" : "Loading")}>
+    <div id="mainContainer" className={"mainContainer" + (initialised ? "" : "Loading")}>
       {initialised ? (
         <>
           <div id="about" className="corner nonselectable" onClick= { () => togglePopup() }>about</div>


### PR DESCRIPTION
The problem was that whenever we did a transform when the window size
changed it would throw off the hit box of the XYPad control region.
It turns out that x/y adjustments have to be applied in the original
coordinate space as opposed to the scaled one. The fix is a dirty one.
We grab the UI scale from the transform property of the main container
and apply an inverse transform to XYPad calculations.